### PR TITLE
upgrade the fastify & fastify-rate-limit to new version

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -125,7 +125,7 @@ let sendRoomWebHook = async function (contact, room) {
     return await _send(token);
 };
 
-fastify.register(require("fastify-rate-limit"), {
+fastify.register(require("@fastify/rate-limit"), {
     max: 100,
     global: false,
 });
@@ -244,7 +244,7 @@ fastify.post(
 
 let start = async function () {
     await bot.start();
-    await fastify.listen(process.env.PORT || 3000);
+    await fastify.listen({port : process.env.PORT || 3000});
     return console.log("listen " + process.env.PORT || 3000);
 };
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "license": "ISC",
     "dependencies": {
         "dotenv": "^10.0.0",
-        "fastify": "^3.19.1",
-        "fastify-rate-limit": "^5.5.0",
+        "fastify": "^4.7.0",
+        "@fastify/rate-limit": "^7.6.0",
         "file-box": "^0.16.8",
         "hot-import": "^0.2.14",
         "lodash": "^4.17.21",


### PR DESCRIPTION
1. this can ognore the `FastifyWarning.fastify-rate-limit: fastify-rate-limit has been deprecated.` warning.
2. new version of fastify has higher performance.